### PR TITLE
Added support for the standard day period type.

### DIFF
--- a/src/datetime.js
+++ b/src/datetime.js
@@ -33,7 +33,8 @@
         'hour':      'Hours',
         'minute':    'Minutes',
         'second':    'Seconds',
-        'dayperiod': 'Hours'
+        'dayperiod': 'Hours',
+        'dayPeriod': 'Hours'
     };
 
     const FORMAT = {
@@ -318,7 +319,7 @@
 
                     }
                     // ignore ampm
-                    if(this.state.type === 'dayperiod') return;
+                    if(this.state.type === 'dayperiod' || this.state.type === 'dayPeriod') return;
                     // ignore Weekday
                     if(this.state.type === 'weekday') return;
 
@@ -380,7 +381,7 @@
             let fnName   = (this.props.useUTC ? 'UTC' : '' ) + hashTypeFn[type],
                 newValue = proxyTime['get' + fnName]();
 
-            if(part.type === 'dayperiod') {
+            if(part.type === 'dayperiod' || part.type === 'dayPeriod') {
                 newValue += operator * 12;
             } else if(part.type === 'weekday') {
                 newValue += operator;


### PR DESCRIPTION
Chrome has a bug - it returns the type as dayperiod instead of dayPeriod and this is probably going to change. Support both of the strings for now.